### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/command/bot/BotInfo.ts
+++ b/src/command/bot/BotInfo.ts
@@ -35,7 +35,7 @@ export default class BotInfo extends Command{
                     process.versions.node,
                     version,
                     client.version.getFullVersion(),
-                    client.version.getLastUpdate().substr(0, 7)
+                    client.version.getLastUpdate().slice(0, 7)
                 )
             )
             .addField(


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.